### PR TITLE
chore: build docker image with github actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,66 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  run:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    env:
+      IMG_NAME: bullmq-proxy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Debug
+        run: |
+          echo "github.ref -> {{ github.ref }}"
+
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.IMG_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value={{sha}},enable=${{ github.ref_type != 'tag' }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          push: true # push to registry
+          pull: true # always fetch the latest base images
+          tags: ghcr.io/taskforcesh/bullmq-proxy:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,10 +7,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
-  pull_request:
-    branches:
-      - '*'
-
 jobs:
   run:
     name: Build and publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,3 @@
-# Configure ENV variables
-# PORT
-# REDIS_HOST,
-# REDIS_PORT
-# REDIS_PASSWORD
-# REDIS_TLS
-# AUTH_TOKENS // comma separated list of tokens
-
 FROM oven/bun:latest
 
 EXPOSE 8080
@@ -15,7 +7,8 @@ COPY bun.lockb ./
 COPY src ./src
 
 RUN bun install
-RUN cd node_modules/@taskforcesh/message-broker && bun run postinstall
 
-CMD bun run ./src/index.ts
+CMD bun start
 HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD wget localhost:8080 -q -O - > /dev/null 2>&1
+
+LABEL org.opencontainers.image.source="https://github.com/taskforcesh/bullmq-proxy"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   proxy:
-    build: .
+    image: ghcr.io/taskforcesh/bullmq-proxy:latest
     ports:
       - 8080:8080
     environment:
@@ -12,4 +12,4 @@ services:
       REDIS_TLS: ${REDIS_TLS}
       AUTH_TOKENS: ${AUTH_TOKENS}
   redis:
-    image: "redis:alpine"
+    image: 'redis:alpine'


### PR DESCRIPTION
This PR adds a Github action to build and publish docker images every time we merge to main, and also if we create new tags based on semver.